### PR TITLE
Fix for null pointer exception using HttpAppender

### DIFF
--- a/src/main/java/tw/kewang/logback/appender/HttpAppender.java
+++ b/src/main/java/tw/kewang/logback/appender/HttpAppender.java
@@ -21,7 +21,7 @@ public class HttpAppender extends HttpAppenderAbstract {
 
 	protected Encoder<ILoggingEvent> encoder;
 	protected Layout<ILoggingEvent> layout;
-	protected String method;
+	protected String method = "POST";
 
 	@Override
 	public void start() {

--- a/src/main/java/tw/kewang/logback/appender/HttpAppender.java
+++ b/src/main/java/tw/kewang/logback/appender/HttpAppender.java
@@ -19,8 +19,6 @@ public class HttpAppender extends HttpAppenderAbstract {
 	 */
 	protected final static String DEFAULT_METHOD = "POST";
 
-	protected Encoder<ILoggingEvent> encoder;
-	protected Layout<ILoggingEvent> layout;
 	protected String method = "POST";
 
 	@Override


### PR DESCRIPTION
A null pointer exception happens ins HttpAppender in createIssue:<br />`			byte[] objEncoded = encoder.encode(event);`<br /><br />encoder is redefined in HttpAppender and the encoder present in  HttpAppenderAbstract is not visible. Removed the local redeclaration so the exception is gone.